### PR TITLE
Configure Android SDK and use Gradle wrapper in Codemagic

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2,8 +2,10 @@ workflows:
   android:
     name: Build APK
     environment:
+      vars:
+        ANDROID_SDK_ROOT: /opt/android-sdk
       java: 17
     scripts:
-      - gradle assembleDebug
+      - ./gradlew assembleDebug
     artifacts:
       - app/build/outputs/**/*.apk


### PR DESCRIPTION
## Summary
- configure `ANDROID_SDK_ROOT` for Codemagic
- use the Gradle wrapper to assemble the debug build

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile /workspace/sms-from-api/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_689b892448f48323892058fda7256198